### PR TITLE
update bundler and Terser mangle options

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -12,4 +12,8 @@ require "bundler/setup"
 
 require "webpacker"
 require "webpacker/webpack_runner"
-Webpacker::WebpackRunner.run(ARGV)
+
+APP_ROOT = File.expand_path("..", __dir__)
+Dir.chdir(APP_ROOT) do
+  Webpacker::WebpackRunner.run(ARGV)
+end

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -12,4 +12,8 @@ require "bundler/setup"
 
 require "webpacker"
 require "webpacker/dev_server_runner"
-Webpacker::DevServerRunner.run(ARGV)
+
+APP_ROOT = File.expand_path("..", __dir__)
+Dir.chdir(APP_ROOT) do
+  Webpacker::DevServerRunner.run(ARGV)
+end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,11 +1,3 @@
 const { environment } = require('@rails/webpacker')
 
-if (environment.plugins.getIndex('UglifyJs') !== -1) {
-  const plugin = environment.plugins.get('UglifyJs');
-  const mangle = plugin.options.uglifyOptions.mangle;
-  if (!mangle.reserved) { mangle.reserved = [] }
-  // Rickshaw needs this special variable with this exact name to work
-  mangle.reserved.push("$super");
-}
-
 module.exports = environment

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
+// Rickshaw, even when minified, needs this special variable with this exact name to work
+environment.config.optimization.minimizer[0].options.terserOptions.mangle.reserved = ["$super"]
+
 module.exports = environment.toWebpackConfig()

--- a/gems.locked
+++ b/gems.locked
@@ -225,4 +225,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   2.0.0.dev
+   2.0.2


### PR DESCRIPTION
This PR does two things:

1. Updates bundler: On deploy, Heroku warns against using the previous buildpack and recommends using the `Heroku/ruby` buildpack directly. I couldn't get this to work without updating bundler.

2. Webpack 4 now ships with `Terser`, which afaict is an alternative to Uglify, and does not include uglify. Since Rickshaw for some reason needs the `$super` variable to remain un-mangled, `$super` has to be added to the reserved list for `Terser` (similar to how it was being done for Uglify)