### PR TITLE
Fix data spikes

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,8 +12,5 @@ class HomeController < ApplicationController
       "CI system" => "ci",
       "TLS ciphers" => "tls_ciphers"
     }
-
-    @latest = Stat.order(:date).first.date
   end
-
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <h1>The Ruby Ecosystem</h1>
-<h3>as of <%= @latest.to_s(:long) %></h3>
+<h3>as of <%= (Date.today - 60.day).to_s(:long) %></h3>
 
 <% @charts.each do |name, key| %>
   <p><%= h name %>, <%= h key %></p>

--- a/app/workers/import_stats_day_worker.rb
+++ b/app/workers/import_stats_day_worker.rb
@@ -18,7 +18,7 @@ class ImportStatsDayWorker
     ImportStatus.transaction do
       ImportStatus.where(id: import_status_ids).update_all(imported_at: Time.now)
 
-      Stat.bulk_insert do |t|
+      Stat.bulk_insert(update_duplicates: %w[date key value], ignore: false) do |t|
         stats.each do |name, value_map|
           value_map.each do |value, count|
             t.add(date: date, key: name, value: value, count: count)

--- a/app/workers/import_stats_file_worker.rb
+++ b/app/workers/import_stats_file_worker.rb
@@ -9,9 +9,11 @@ class ImportStatsFileWorker
 
     body = s3.get_object(bucket: bucket, key: key).body.read
     json = JSON.parse(body)
-    date, data = json.keys.first, json.values.first
 
-    ImportStatus.create!(key: key, date: date, data: data)
+    json.each do |date, data|
+      ImportStatus.create!(key: key, date: date, data: data)
+    end
+
     Rails.logger.info("Downloaded #{key}")
   end
 end

--- a/app/workers/import_stats_worker.rb
+++ b/app/workers/import_stats_worker.rb
@@ -6,7 +6,7 @@ class ImportStatsWorker
     bucket_name = Rails.application.config.stats.bucket_name
     prefix = Rails.application.config.stats.prefix
 
-    last_key = ImportStatus.order("key DESC").limit(1).pluck(:key).first
+    last_key = ImportStatus.order('key COLLATE "C" DESC').limit(1).pluck(:key).first
     keys = s3.list_objects_v2(
       bucket: bucket_name,
       prefix: prefix,
@@ -20,5 +20,4 @@ class ImportStatsWorker
       'args' => keys.map{|k| [k] }
     )
   end
-
 end

--- a/db/migrate/20190708173946_add_timestamps_to_stats.rb
+++ b/db/migrate/20190708173946_add_timestamps_to_stats.rb
@@ -1,5 +1,5 @@
 class AddTimestampsToStats < ActiveRecord::Migration[5.2]
   def change
-    add_timestamps :stats
+    add_timestamps :stats, null: true
   end
 end

--- a/db/migrate/20190713153752_add_unique_index_to_stats.rb
+++ b/db/migrate/20190713153752_add_unique_index_to_stats.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToStats < ActiveRecord::Migration[5.2]
+  def change
+    add_index :stats, [:date, :key, :value], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_08_173946) do
+ActiveRecord::Schema.define(version: 2019_07_13_153752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2019_07_08_173946) do
     t.integer "count", default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["date", "key", "value"], name: "index_stats_on_date_and_key_and_value", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,8 +31,8 @@ ActiveRecord::Schema.define(version: 2019_07_08_173946) do
     t.string "key", null: false
     t.string "value", null: false
     t.integer "count", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end

--- a/gems.locked
+++ b/gems.locked
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/jamis/bulk_insert.git
+  revision: 3ded6b059af8d239ca0f5fbecca0de6138d49592
+  specs:
+    bulk_insert (1.7.0)
+      activerecord (>= 3.2.0)
+
 GEM
   remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
@@ -64,8 +71,6 @@ GEM
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
-    bulk_insert (1.7.0)
-      activerecord (>= 3.2.0)
     byebug (11.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
@@ -203,7 +208,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1.45)
   bootsnap (>= 1.1.0)
-  bulk_insert (~> 1.7)
+  bulk_insert!
   concurrent-ruby
   connection_pool
   listen (>= 3.0.5, < 3.2)

--- a/gems.rb
+++ b/gems.rb
@@ -7,7 +7,7 @@ gem "rails", "~> 5.2.2"
 
 gem "aws-sdk-s3", "~> 1.45"
 gem "bootsnap", ">= 1.1.0", require: false
-gem "bulk_insert", "~> 1.7"
+gem "bulk_insert", git: "https://github.com/jamis/bulk_insert.git"
 gem "pg", ">= 0.18", "< 2.0"
 gem "puma", "~> 4.0"
 gem "sidekiq", "~> 5.2"

--- a/lib/tasks/temporary.rake
+++ b/lib/tasks/temporary.rake
@@ -1,0 +1,7 @@
+namespace :temporary do
+  desc "one-off tasks"
+  task destroy_duplicate_stats: :environment do
+    # delete all duplicate rows preserving the row with the maximum count
+    Stat.where.not(id: Stat.order(:date, :key, :value, "count desc").select("distinct on (date, key, value) id")).delete_all
+  end
+end


### PR DESCRIPTION
This PR does the following:

1. Fix data spikes
    a. Adds a unique index to the `stats` table on `(date, key, value)`. 
    b. Add a rake task to delete existing duplicate rows in the `stats` table. Another option would have been to make a partial index, but this interferes with how `bulk_insert` works.
    c. Upgrade `bulk_insert` to `master` as this gives us the functionality on `update_duplicates` as described in the readme. I suspect eventually we can upgrade to Rails 6 and make use of `upsert`.
    d. In the import stats day worker, ensure we use all available date keys per log file.

2. Reduce data scope to 60 days (for now)

3. Update a timestamps migration which never ran because of existing mismatches.

4. I noticed that the sort order in `ImportStatsWorker` in the line:
    ```
         last_key = ImportStatus.order('key DESC').limit(1).pluck(:key).first
    ```
    was returning different values on Heroku vs locally (and as compared to ruby's sort). This is pretty harmless because we have a guard that prevents creating extra rows. Imposing a collation on the sort equalizes the sort order everywhere:

    ```
        last_key = ImportStatus.order('key COLLATE "C" DESC').limit(1).pluck(:key).first
    ```