### PR TITLE
add a content security policy for stylesheet blobs in localhost

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,6 +17,7 @@ Rails.application.config.content_security_policy do |policy|
 
   if Rails.env.development?
     policy.connect_src :self, :https, "http://localhost:3036", "ws://localhost:3035"
+    policy.style_src   :self, :blob
   end
 end
 


### PR DESCRIPTION
Stylesheets are served as blobs when in development, and thus were getting blocked by the content security policy.