### PR TITLE
bundler vs rubygems and ci vs non-ci

### DIFF
--- a/app/controllers/comparison_controller.rb
+++ b/app/controllers/comparison_controller.rb
@@ -3,11 +3,9 @@ class ComparisonController < ApplicationController
     key1 = params.fetch(:key1)
     key2 = params.fetch(:key2)
     # TODO: extract range processing out - this is duplicated in VersionsController
-    range = RANGES[params[:range] || "3months"]
+    range = DateRange.new(params)
 
-    range_prefix = params[:range] === "1year" ? "weekly_" : "daily_"
-
-    data = Stat.send(range_prefix + "comparison", key1, key2, range)
+    data = Stat.send(range.prefix + "comparison", key1, key2, range.value)
 
     dates = data.map(&:first).sort.uniq
     count_map = Hash.new { |h, k| h[k] = {} }
@@ -38,14 +36,4 @@ class ComparisonController < ApplicationController
       format.js { render "versions/show" }
     end
   end
-
-  private
-
-  RANGES = {
-    "1year" => Date.today - 1.year,
-    "3months" => Date.today - 90.days,
-    "1month" => Date.today - 30.days,
-    "2weeks" => Date.today - 2.weeks
-  }
-  RANGES.default = Date.today - 90.days
 end

--- a/app/controllers/comparison_controller.rb
+++ b/app/controllers/comparison_controller.rb
@@ -2,7 +2,6 @@ class ComparisonController < ApplicationController
   def show
     key1 = params.fetch(:key1)
     key2 = params.fetch(:key2)
-    # TODO: extract range processing out - this is duplicated in VersionsController
     range = DateRange.new(params)
 
     data = Stat.send(range.prefix + "comparison", key1, key2, range.value)

--- a/app/controllers/comparison_controller.rb
+++ b/app/controllers/comparison_controller.rb
@@ -1,0 +1,51 @@
+class ComparisonController < ApplicationController
+  def show
+    key1 = params.fetch(:key1)
+    key2 = params.fetch(:key2)
+    # TODO: extract range processing out - this is duplicated in VersionsController
+    range = RANGES[params[:range] || "3months"]
+
+    range_prefix = params[:range] === "1year" ? "weekly_" : "daily_"
+
+    data = Stat.send(range_prefix + "comparison", key1, key2, range)
+
+    dates = data.map(&:first).sort.uniq
+    count_map = Hash.new { |h, k| h[k] = {} }
+    data.each { |date, key, count| count_map[date][key] = count }
+
+    key1_points =
+      dates.map do |date|
+        count = count_map.dig(date, key1) - count_map.dig(date, key2)
+        y = count.to_f / count_map.dig(date, key1) * 100
+        { x: date.strftime("%m/%d"), y: y }
+      end
+
+    key1_series = { name: key1, data: key1_points }
+
+    key2_points =
+      dates.map do |date|
+        count = count_map.dig(date, key2)
+        y = count.to_f / count_map.dig(date, key1) * 100
+        { x: date.strftime("%m/%d"), y: y }
+      end
+
+    key2_series = { name: key2, data: key2_points }
+
+    @series = [key1_series, key2_series]
+
+    respond_to do |format|
+      format.json { render json: @series }
+      format.js { render "versions/show" }
+    end
+  end
+
+  private
+
+  RANGES = {
+    "1year" => Date.today - 1.year,
+    "3months" => Date.today - 90.days,
+    "1month" => Date.today - 30.days,
+    "2weeks" => Date.today - 2.weeks
+  }
+  RANGES.default = Date.today - 90.days
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,7 +9,8 @@ class HomeController < ApplicationController
       "Platform" => "/versions/platform",
       "CI system" => "/versions/ci",
       "TLS ciphers" => "/versions/tls_cipher",
-      "Rubygems vs Bundler" => "/comparison/ruby/bundler"
+      "Rubygems vs Bundler" => "/comparison/ruby/bundler",
+      "CI vs non-CI" => "/comparison/bundler/ci"
     }
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,12 +3,13 @@ class HomeController < ApplicationController
     return render plain: "No data!" if Stat.count.zero?
 
     @charts = {
-      "Ruby version" => "ruby",
-      "Bundler version" => "bundler",
-      "RubyGems version" => "rubygems",
-      "Platform" => "platform",
-      "CI system" => "ci",
-      "TLS ciphers" => "tls_cipher"
+      "Ruby" => "/versions/ruby",
+      "Bundler version" => "/versions/bundler",
+      "RubyGems version" => "/versions/rubygems",
+      "Platform" => "/versions/platform",
+      "CI system" => "/versions/ci",
+      "TLS ciphers" => "/versions/tls_cipher",
+      "Rubygems vs Bundler" => "/comparison/ruby/bundler"
     }
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,7 +9,7 @@ class HomeController < ApplicationController
       "Platform" => "/versions/platform",
       "CI system" => "/versions/ci",
       "TLS ciphers" => "/versions/tls_cipher",
-      "Rubygems vs Bundler" => "/comparison/ruby/bundler",
+      "Rubygems vs Bundler" => "/comparison/rubygems/bundler",
       "CI vs non-CI" => "/comparison/bundler/ci"
     }
   end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,10 +1,10 @@
 class VersionsController < ApplicationController
   def show
-    @key = params.fetch(:key)
+    key = params.fetch(:key)
     range = DateRange.new(params)
 
-    data = Stat.send(range.prefix + "data", @key, range.value)
-    date_totals = Stat.send(range.prefix + "totals", @key, range.value)
+    data = Stat.send(range.prefix + "data", key, range.value)
+    date_totals = Stat.send(range.prefix + "totals", key, range.value)
 
     if params[:total]
       points =
@@ -22,7 +22,7 @@ class VersionsController < ApplicationController
       # [ {name: "2.2.2", data: [{x: "2018-07-13", y: 3932}, ...] }, ... ]
       versions = count_map.values.flat_map(&:keys).compact.sort.uniq
       top =
-        versions.max_by(MAXES[@key]) do |v|
+        versions.max_by(MAXES[key]) do |v|
           count_map[count_map.keys.last][v] || 0
         end
 
@@ -35,7 +35,7 @@ class VersionsController < ApplicationController
               { x: date.strftime("%m/%d"), y: y }
             end
 
-          { name: "#{@key} #{version}", data: points }
+          { name: "#{key} #{version}", data: points }
         end
 
       if top.length < versions.length

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,11 +1,10 @@
 class VersionsController < ApplicationController
   def show
     @key = params.fetch(:key)
-    range = RANGES[params[:range] || "3months"]
+    range = DateRange.new(params)
 
-    range_prefix = params[:range] === "1year" ? "weekly_" : "daily_"
-    data = Stat.send(range_prefix + "data", @key, range)
-    date_totals = Stat.send(range_prefix + "totals", @key, range)
+    data = Stat.send(range.prefix + "data", @key, range.value)
+    date_totals = Stat.send(range.prefix + "totals", @key, range.value)
 
     if params[:total]
       points =
@@ -62,14 +61,6 @@ class VersionsController < ApplicationController
   end
 
   private
-
-  RANGES = {
-    "1year" => Date.today - 1.year,
-    "3months" => Date.today - 90.days,
-    "1month" => Date.today - 30.days,
-    "2weeks" => Date.today - 2.weeks
-  }
-  RANGES.default = Date.today - 90.days
 
   MAXES = { "ci" => 7 }
   MAXES.default = 10

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,15 +1,11 @@
-class StatsController < ApplicationController
+class VersionsController < ApplicationController
   def show
-    @key = params.fetch(:id)
+    @key = params.fetch(:key)
     range = RANGES[params[:range] || "3months"]
 
-    if params[:range] == "1year"
-      data = Stat.weekly_data(@key, range)
-      date_totals = Stat.weekly_totals(@key, range)
-    else
-      data = Stat.daily_data(@key, range)
-      date_totals = Stat.daily_totals(@key, range)
-    end
+    range_prefix = params[:range] === "1year" ? "weekly_" : "daily_"
+    data = Stat.send(range_prefix + "data", @key, range)
+    date_totals = Stat.send(range_prefix + "totals", @key, range)
 
     if params[:total]
       points =

--- a/app/lib/date_range.rb
+++ b/app/lib/date_range.rb
@@ -1,0 +1,20 @@
+class DateRange
+  RANGES = {
+    "1year" => Date.today - 1.year,
+    "3months" => Date.today - 90.days,
+    "1month" => Date.today - 30.days,
+    "2weeks" => Date.today - 2.weeks
+  }
+
+  RANGES.default = Date.today - 90.days
+
+  attr_reader :value
+
+  def initialize(params)
+    @value = RANGES[params[:range]]
+  end
+
+  def prefix
+    @value > RANGES["1year"] ? "daily_" : "weekly_"
+  end
+end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -36,6 +36,21 @@ class Stat < ApplicationRecord
     end
   end
 
+  def self.daily_comparison(key1, key2, range)
+    Stat.where("(key = ? OR key = ?) AND date > ?", key1, key2, range).where
+      .not(value: "")
+      .group(:date, :key)
+      .order(:date)
+      .pluck(:date, :key, sum)
+  end
+
+  def self.weekly_comparison(key1, key2, range)
+    Stat.where("(key = ? OR key = ?) AND date > ?", key1, key2, range).where
+      .not(value: "")
+      .group(:week, :key)
+      .pluck(week, :key, sum)
+  end
+
   private
 
   BUCKETS = {

--- a/app/views/home/_chart.js.erb
+++ b/app/views/home/_chart.js.erb
@@ -1,5 +1,5 @@
 Rails.ajax({
-  url: "/stats/<%= CGI.escape(key) %>",
+  url: "<%= path %>",
   type: "get",
   success: series => {
     const options = {
@@ -7,7 +7,7 @@ Rails.ajax({
         width: 2
       },
       chart: {
-        id: "chart-<%= CGI.escape(key) %>",
+        id: "chart-<%= path.parameterize %>",
         height: 400,
         animations: {
           enabled: false
@@ -58,7 +58,7 @@ Rails.ajax({
       }
     };
     new ApexCharts(
-      document.querySelector("#<%= key %>-graph"),
+      document.querySelector("#<%= path.parameterize %>-graph"),
       options
     ).render();
   }

--- a/app/views/home/_totals.js.erb
+++ b/app/views/home/_totals.js.erb
@@ -1,5 +1,5 @@
 Rails.ajax({
-  url: "/stats/<%= CGI.escape(key) %>?total=true",
+  url: "/versions/<%= CGI.escape(key) %>?total=true",
   type: "get",
   success: series => {
     const options = {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,35 +1,32 @@
 <h1>The Ruby Ecosystem</h1>
 <h3>as of <%= (Date.today - 60.day).to_s(:long) %></h3>
 
+<% @charts.each do | name, path | %>
+  <p><%= h name %></p>
+  <%= content_tag :div, class: "#{path.parameterize}-graph-ranges" do %>
+    <%= link_to "YTD", "#{path}?range=1year", remote: true %>
+    <%= link_to "3m", "#{path}?range=3months", remote: true %>
+    <%= link_to "1m", "#{path}?range=1month", remote: true %>
+    <%= link_to "2w", "#{path}?range=2weeks", remote: true %>
+  <% end %>
 
-<% @charts.each do | name, key | %>
-  <p><%= h name %>, <%= h key %></p>
-  <%= content_tag :div, class: "#{key}-graph-ranges" do %>
-    <%= link_to "YTD", "/stats/#{CGI.escape(key)}?range=1year", remote: true %>
-    <%= link_to "3m", "/stats/#{CGI.escape(key)}?range=3months", remote: true %>
-    <%= link_to "1m", "/stats/#{CGI.escape(key)}?range=1month", remote: true %>
-    <%= link_to "2w", "/stats/#{CGI.escape(key)}?range=2weeks", remote: true %>
-  <%end %>
-
-  <%= content_tag :div, id: "#{key}-graph" do %>
-  <%end %>
-
-
+  <%= content_tag :div, id: "#{path.parameterize}-graph" do %>
+  <% end %>
 <% end %>
 
 <%= content_tag :div, class: "ruby-total-ranges" do %>
-  <%= link_to "YTD", "/stats/ruby?total=true&range=1year", remote: true %>
-  <%= link_to "3m", "/stats/ruby?total=true&range=3months", remote: true %>
-  <%= link_to "1m", "/stats/ruby?total=true&range=1month", remote: true %>
-  <%= link_to "2w", "/stats/ruby?total=true&range=2weeks", remote: true %>
+  <%= link_to "YTD", "/versions/ruby?total=true&range=1year", remote: true %>
+  <%= link_to "3m", "/versions/ruby?total=true&range=3months", remote: true %>
+  <%= link_to "1m", "/versions/ruby?total=true&range=1month", remote: true %>
+  <%= link_to "2w", "/versions/ruby?total=true&range=2weeks", remote: true %>
 <%end %>
 
 <%= content_tag :div, id: "ruby-total" do %>
 <% end %>
 
 <script>
-  <% @charts.each do |name, key| %>
-      <%= render partial: "chart", locals: {key: key}, handlers: [:erb], formats: [:js] %>
+  <% @charts.each do |name, path| %>
+      <%= render partial: "chart", locals: {path: path}, handlers: [:erb], formats: [:js] %>
   <% end %>
   <%= render partial: "totals", locals: {key: "ruby"}, handlers: [:erb], formats: [:js] %>
 </script>

--- a/app/views/stats/show.js.erb
+++ b/app/views/stats/show.js.erb
@@ -1,1 +1,0 @@
-ApexCharts.exec('<%= @total ? "totals-" : "" %>chart-<%= @key %>', 'updateSeries', JSON.parse(`<%= raw(@series.to_json) %>`), true);

--- a/app/views/versions/show.js.erb
+++ b/app/views/versions/show.js.erb
@@ -1,0 +1,3 @@
+ApexCharts.exec('<%= @total ? "totals-" : "" %>chart-<%= request.path.parameterize %>', 
+                'updateSeries', 
+                JSON.parse(`<%= raw(@series.to_json) %>`), true);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
-  get "stats/:id" => "stats#show"
+  get "versions/:key" => "versions#show"
+  get "comparison/:key1/:key2" => "comparison#show"
   root "home#index"
 end


### PR DESCRIPTION
Calculations:

**Bundler vs rubygems**

Bundler traffic - summed count from Stat rows with key = "bundler"
Rubygems traffic - (summed count from Stat rows with key = "rubygems") minus corresponding bundler traffic number

**CI vs non-CI**

CI traffic - summed count from Stat rows with key = "ci"
"non-CI" traffic - summed count from Stat rows with key = "bundler" minus corresponding CI traffic number (assumption here being that only bundler reports CI value and is therefore the correct "superset")

@indirect this results in a graph which has CI traffic at about 1%. does this seem correct to you?

Implementation notes:
* Rename StatsController to VersionsController
* Introduce a new controller called ComparisonController
* Add two methods to Stats model to get comparison data