### PR TITLE
Also group _unique stats

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -60,6 +60,7 @@ class Stat < ApplicationRecord
     "ci" => :ci,
     "platform" => :platform
   }
+  BUCKETS.merge!(BUCKETS.transform_keys { |k| "#{k}_unique" })
 
   PLATFORMS = %w[linux mingw32 darwin java]
 


### PR DESCRIPTION
Followup: https://github.com/rubytogether/ecosystem/pull/473

This is needed so the same minor version grouping is applied to `_unique` stats.

cc @indirect 