### PR TITLE
Tweak versions limits

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -65,7 +65,7 @@ class VersionsController < ApplicationController
 
   private
 
-  DEFAULT_LIMITS = { "platform" => 3 }
+  DEFAULT_LIMITS = { "ruby_unique" => 7 }
   DEFAULT_LIMITS.default = 5
   MAX_LIMIT = 25
 


### PR DESCRIPTION
For ruby_unique a limit of 5 hides Ruby 3.0 and 3.1, I think we can afford displaying two more.

For platform, the limit of 5 adds `darwin` which I think is relevant.