### PR TITLE
Fix seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,11 +2,12 @@ require "csv"
 
 data_file = File.expand_path("seeds/stats.csv", __dir__)
 
+created_at = Time.now
+
 stats = []
-CSV.foreach(data_file) { |row| stats.push([row[0..2].join("-"), *row[3..-1]]) }
+CSV.foreach(data_file) { |row| stats.push([[created_at.year, *row[1..2]].join("-"), *row[3..-1]]) }
 stats.shift
 
-created_at = Time.now
 stat_values =
   stats.map do |s|
     s.push(created_at, created_at)


### PR DESCRIPTION
Since a unique index on stats was added at https://github.com/rubytogether/ecosystem/commit/da4e600dbb13899bcab05be8383dd9c584e18bd4, the current seeds file no longer loads, since it has entries violating this constraint. It shows errors like this:

```

rails aborted!
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_stats_on_date_and_key_and_value"
DETAIL:  Key (date, key, value)=(2018-03-02, ruby, 2.3.1) already exists.
/Users/deivid/Code/rubytogether/ecosystem/db/seeds.rb:22:in `<main>'
bin/rails:4:in `<main>'

Caused by:
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_stats_on_date_and_key_and_value"
DETAIL:  Key (date, key, value)=(2018-03-02, ruby, 2.3.1) already exists.
````

The first commit in this PR cleans up the CSV seeds file to only have entries with unique (date, key, value).

Since I was at it, I also changed seeds to automatically use the current year for all stats, instead of 2018, so that the data shows up in the home page by default.