### PR TITLE
Fix "RubyGems vs Bundler" and "CI vs Non-CI" legends in unique view

### DIFF
--- a/app/controllers/comparison_controller.rb
+++ b/app/controllers/comparison_controller.rb
@@ -19,8 +19,11 @@ class ComparisonController < ApplicationController
         { x: date.strftime("%m/%d"), y: y }
       end
 
+    key1_without_unique = key1.delete_suffix("_unique")
+    key2_without_unique = key2.delete_suffix("_unique")
+
     # TODO: Make this more general
-    key1_name = key1 == "bundler" && key2 == "ci" ? "Non-CI" : key1
+    key1_name = key1_without_unique == "bundler" && key2_without_unique == "ci" ? "Non-CI" : key1_without_unique
     key1_series = { name: key1_name, data: key1_points }
 
     key2_points =
@@ -30,7 +33,7 @@ class ComparisonController < ApplicationController
         { x: date.strftime("%m/%d"), y: y }
       end
 
-    key2_name = key2 == "ci" ? "CI" : key2
+    key2_name = key2_without_unique == "ci" ? "CI" : key2_without_unique
     key2_series = { name: key2_name, data: key2_points }
 
     @series = [key1_series, key2_series]


### PR DESCRIPTION
### Before

<img width="1108" alt="Captura de Pantalla 2022-05-11 a las 18 48 37" src="https://user-images.githubusercontent.com/2887858/167904219-e00a4a5f-f847-4f51-b4f9-6f1e1ce02d0b.png">
<img width="1096" alt="Captura de Pantalla 2022-05-11 a las 18 48 46" src="https://user-images.githubusercontent.com/2887858/167904227-c414bad9-d092-4b51-be04-7c80bf6366ee.png">

### After

<img width="1095" alt="Captura de Pantalla 2022-05-11 a las 18 46 12" src="https://user-images.githubusercontent.com/2887858/167904189-662beb14-bd14-4c92-9f31-e006f21866a3.png">
<img width="1082" alt="Captura de Pantalla 2022-05-11 a las 18 46 20" src="https://user-images.githubusercontent.com/2887858/167904210-8dc327e7-28e3-46f8-a088-e73e48dda6aa.png">

